### PR TITLE
Add feature to include a base64 encoded license via command line argu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ If a file is not tracked by Git, the current year is used as start year.
 The end year is automatically set to the current year
 (`--use-current-year` is activated automatically when `--dynamic-years` is present).
 
-The argument `--license-filepath` can be omitted, the license header then defaults to the one specified in this repository at `pre_commit_insert_qc_license/LICENSE.header`,
-this is currently set to a default QuantCo license.
-Including a LICENSE file from your local repository via `--license-filepath` overrides the default license header.
+Add argument `--license-base64` to include a license not via a file but through
+a `base64`` encoded string that is passed as value for this argument.
+Obtain your license `base64` encoded string with `cat LICENSE.txt | base64`.
+Including a license via `--license-base64 {base64string}` overrides the
+`--license-filepath` option.
 
 Usage: (in `.pre-commit-config.yaml`)
 
 ```
 - repo: https://github.com/Quantco/pre-commit-insert-qc-license
-    rev: v1.7.1
+    rev: v1.7.2
     hooks:
       - id: insert-license
         files: \.py$

--- a/pre_commit_insert_qc_license/LICENSE.header
+++ b/pre_commit_insert_qc_license/LICENSE.header
@@ -1,2 +1,0 @@
-Copyright (c) QuantCo {year_start}-{year_end}
-SPDX-License-Identifier: LicenseRef-QuantCo

--- a/pre_commit_insert_qc_license/insert_license.py
+++ b/pre_commit_insert_qc_license/insert_license.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import collections
-import os
 import re
 import subprocess
 import sys
@@ -47,7 +47,8 @@ class LicenseUpdateError(Exception):
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("filenames", nargs="*", help="filenames to check")
-    parser.add_argument("--license-filepath", default=None)
+    parser.add_argument("--license-filepath", default="LICENSE.txt")
+    parser.add_argument("--license-base64")
     parser.add_argument(
         "--comment-style",
         default="#",
@@ -161,10 +162,11 @@ def get_license_info(args) -> LicenseInfo:
     if "|" in comment_prefix:
         comment_start, comment_prefix, comment_end = comment_prefix.split("|")
 
-    if args.license_filepath is None:
-        current_dir = os.path.dirname(os.path.realpath(__file__))
-        plain_license = open(current_dir + "/LICENSE.header").readlines()
-    else:
+    if args.license_base64:  # obtain plain_license by decoding base64_license string
+        decoded_license = base64.b64decode(args.license_base64).decode()
+        plain_license = [line + "\n" for line in decoded_license.splitlines()]
+
+    else:  # read plain_license from file
         with open(args.license_filepath, encoding="utf8", newline="") as license_file:
             plain_license = license_file.readlines()
 


### PR DESCRIPTION
…ments instead of a file.

Add argument '--license-base64' to include a license not via a file but through a 'base64' encoded string that is passed as value for this argument.