### PR TITLE
Make '_get_git_file_creation_date' more robust.

### DIFF
--- a/insert_license_header/insert_license.py
+++ b/insert_license_header/insert_license.py
@@ -740,10 +740,16 @@ def _get_git_file_creation_date(filepath):
     :return: year of creation
     :rtype: int
     """
-    command = f'git log --follow --format="%aI" -- {filepath}'
-    result = subprocess.run(
-        command, shell=True, text=True, capture_output=True, check=True
-    )
+    command = f'git log --follow --format="%aI" -- "{filepath}"'
+
+    try:
+        result = subprocess.run(
+            command, shell=True, text=True, capture_output=True, check=True
+        )
+    except (
+        subprocess.CalledProcessError
+    ):  # Cover edge cases, e.g. if there has been no commit yet
+        return datetime.now()
 
     # The result.stdout will contain all the commit dates, one per line.
     # The last line will be the date of the first commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "insert-license-header"
 description = "Tool to insert license headers at the beginning of text-based files."
 readme = "README.md"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = [
   {name = "Thomas Marwitz", email = "thomasmarwitz3@gmail.com"},

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -743,6 +743,17 @@ def test_dynamic_years(
         assert updated_content == expected_content
 
 
+def test_git_file_creation_date(monkeypatch):
+    """Mock subprocess.run to throw an exception. Expect the returned datetime to have this year!"""
+
+    def mock_git_log(*args, **kwargs):
+        raise subprocess.CalledProcessError(128, "git log")
+
+    monkeypatch.setattr(subprocess, "run", mock_git_log)
+    result = _get_git_file_creation_date("Not existing")
+    assert result.year == datetime.now().year
+
+
 def test_base64_encoded_license(tmpdir):
     base64_license = "Q29weXJpZ2h0IChDKSAyMDQyLCBQZWFyQ29ycCwgSW5jLgpTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogTGljZW5zZVJlZi1QZWFyQ29ycAo="
 


### PR DESCRIPTION
Escape the file path with quotes.
If an exception occurs, return the current date.