### PR TITLE
Re-Implement behaviour  of `--dynamic-years` flag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,25 @@
 Changelog
 =========
 
+Insert-license-header 1.1.0
+================================================
+* Re-implement behaviour `--dynamic-years`
+    * The end year is now also determined by GIT, the current year is NOT automtically used.
+    * Effectively, the tool will not upgrade the year of files that have not been touched,
+      this is important when using the pre-commit hook of this tool. Prior `1.1.0`,
+      `pre-commit run insert-license -a` would cause your CI to go red after New Year's Eve.
+* Fix link to the actual pre-commit repository.
+
+Insert-license-header 1.0.2
+================================================
+* Make function that determines git start date more robust
+    * If, e.g. no GIT repository exists, the tool will no longer fail but use the current year.
+    * The path to the file is escaped, allowing for more crazy file names.
+
+Insert-license-header 1.0.1
+================================================
+* (Re-trigger publishing workflow)
+
 Insert-license-header 1.0.0 (2023-11-07)
 ================================================
 * Tool is a standalone pypi tool and no longer a pre-commit hook

--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@ This python script automatically inserts your license header at the beginning of
 
 Forked from [Lucas-C/pre-commit-hooks](https://github.com/Lucas-C/pre-commit-hooks) and modified to realize the following behaviour:
 
+> :warning: The behaviour of `--dynamic-years` changed in version `1.1.0`.
+>
 Add argument `--dynamic-years` which determines the start year of the copyright time range automatically - based on when
 the file was first tracked with Git. If a start year is already present, it is not touched.
 If a file is not tracked by Git, the current year is used as start year.
-The end year is automatically set to the current year
-(`--use-current-year` is activated automatically when `--dynamic-years` is present).
+The end year is automatically set to the date of the last commit that affected the file.
+If an end year is already present that is in the future, don't touch it. It is, however,
+incremented if it lies in the past. If the file is not tracked by Git, use the current year.
+
 Include a `{year_start}` and `{year_end}` in your license header to use this feature.
 
 Add argument `--license-base64` to include a license not via a file but through

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Obtain your license `base64` encoded string with `cat LICENSE.txt | base64`.
 Including a license via `--license-base64 {base64string}` overrides the
 `--license-filepath` option.
 
-> :warning: This is not a pre-commit hook anymore. Instead, this repository contains just the base script to insert licenses in text-based files. To check out the resulting pre-commit hook, visit: https://github.com/Quantco/pre-commit-insert-license)https://github.com/Quantco/pre-commit-insert-license.
+> :warning: This is not a pre-commit hook anymore. Instead, this repository contains just the base script to insert licenses in text-based files. To check out the resulting pre-commit hook, visit: https://github.com/Quantco/pre-commit-insert-license

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "insert-license-header"
 description = "Tool to insert license headers at the beginning of text-based files."
 readme = "README.md"
-version = "1.0.2"
+version = "1.1.0"
 license = "MIT"
 authors = [
   {name = "Thomas Marwitz", email = "thomasmarwitz3@gmail.com"},


### PR DESCRIPTION
The feature `--dynamic-years` is re-implemented s.t. the end year is determined by
1. GIT (last modification date, but only increments the year, e.g. we do not decrement a year that is already if the file has been modified the last time a year before)
2. FILE (trust the date already present)
3. CURRENT_YEAR (only if no date is already present in the file & the file is not tracked by GIT).

The previous behaviour of `--dynamic-years` regarding `start_year` remains intact.