### PR TITLE
Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout code 🛎️
         uses: actions/checkout@v3
 
+      - name: Check shallow env
+        run: git rev-parse --is-shallow-repository
+
       - name: Set up Python ${{ matrix.python-version }} 🔧
         uses: actions/setup-python@v3
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Remove verbose output logs
+* In certain circumstances, insert-license would need to be run twice to update its year
+* Detect whether in a shallow environment
+
 Insert-license-header 1.1.0
 ================================================
 * Re-implement behaviour `--dynamic-years`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,9 +2,14 @@
 Changelog
 =========
 
+
+Insert-license-header 1.3.0
+================================================
+* Fix issue #9: Avoid needing to re-run insert-license-header tool in cases where a
+  modification would lead to a newer git end year that is not yet present in the file.
+* Detect whether in a shallow git repo, if yes, don't trust GIT
 * Remove verbose output logs
-* In certain circumstances, insert-license would need to be run twice to update its year
-* Detect whether in a shallow environment
+
 
 Insert-license-header 1.2.0
 ================================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changelog
 * In certain circumstances, insert-license would need to be run twice to update its year
 * Detect whether in a shallow environment
 
+Insert-license-header 1.2.0
+================================================
+* Added debugging functionality, can be triggered by providing `--debug`.
+
+
 Insert-license-header 1.1.0
 ================================================
 * Re-implement behaviour `--dynamic-years`

--- a/insert_license_header/insert_license.py
+++ b/insert_license_header/insert_license.py
@@ -242,6 +242,7 @@ def process_files(args, changed_files, todo_files, license_info: LicenseInfo):
         license_info = plain_license_info
 
         current_end_year = datetime.now().year
+        logging.debug(f"Current end year: {current_end_year}")
         if args.dynamic_years:
             existing_year_range = _get_existing_year_range(src_filepath)
             logging.debug(f"Existing year range: {existing_year_range}")
@@ -265,6 +266,11 @@ def process_files(args, changed_files, todo_files, license_info: LicenseInfo):
                     # the changes are committed. `insert-license` would have
                     # to be run again.
                     PREFER_GIT_OVER_CURRENT_YEAR = False
+                    logging.debug(
+                        "Existing year range is smaller than git year range."
+                        "Git year range is smaller than current year."
+                        "Setting 'PREFER_GIT_OVER_CURRENT_YEAR = False'."
+                    )
 
             current_end_year = (
                 git_year_end if PREFER_GIT_OVER_CURRENT_YEAR else current_end_year

--- a/insert_license_header/insert_license.py
+++ b/insert_license_header/insert_license.py
@@ -157,18 +157,6 @@ def main(argv=None):
     logging.debug(f"Changed files: {changed_files}\n")
 
     if check_failed:
-        print("")
-        if changed_files:
-            print(f"Some sources were modified by the hook {changed_files}")
-        if todo_files:
-            print(
-                f"Some sources contain TODO about inconsistent licenses: {todo_files}"
-            )
-        print("Now aborting the commit.")
-        print(
-            'You should check the changes made. Then simply "git add --update ." and re-commit'
-        )
-        print("")
         return 1
     return 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "insert-license-header"
 description = "Tool to insert license headers at the beginning of text-based files."
 readme = "README.md"
-version = "1.2.0"
+version = "1.3.0"
 license = "MIT"
 authors = [
   {name = "Thomas Marwitz", email = "thomasmarwitz3@gmail.com"},

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from itertools import chain, product
 
 import pytest
-
 from insert_license_header.insert_license import (
     LicenseInfo,
     _get_git_file_year_range,
@@ -704,8 +703,10 @@ def get_datetime_range(year_range: str):
         # GIT tracked: Test END_YEAR.
         # -> GIT tracking or year in file should always have precedence over current year
         ################################################################################
-        ("2020-2022", "2020-2023", "2024", "2020-2023"),
-        # --> Update 'end_year' if git is newer, prioritize git > current year
+        ("2020-2022", "2020-2023", "2024", "2020-2024"),
+        # --> Update 'end_year' if git is newer, prioritize current year
+        # Because otherwise, the updated file would be modified, i.e. git end year is
+        # now also current year.
         ("2020-2023", "2020-2022", "2024", "2020-2023"),
         # --> Keep 'end_year' if git is older, prioritize 'year in file' > current year
         ("2020-2022", "2020-2022", "2024", "2020-2022"),

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -806,14 +806,21 @@ def test_dynamic_years_with_existing_license_header(
         assert updated_content == expected_content
 
 
-# TESTCASES:
-# File's last_year is now 2024 (prev 2023)
-# File's last_year is still 2023 (current year = 2024)
-# File's start_year
+def test_git_ignored_in_shallow_repo(monkeypatch, tmp_path):
+    """Mock subprocess.run to throw an exception. Expect the returned datetime to have this year!"""
 
-# 1. File has no license header:
-#   - Git tracked: take from git
-#   - Not Git tracked: take current-current
+    def mock_shallow_test(cmd, **kwargs):
+        assert "git rev-parse --is-shallow-repository" in cmd
+        return type("mock", (), {"stdout": "true"})
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        mock_shallow_test,
+    )
+
+    result = _get_git_file_year_range("some-non-existant-file.py")
+    assert result is None
 
 
 def test_git_file_creation_date(monkeypatch):


### PR DESCRIPTION
Fixes #9 

Remove verbose print output at the end.

Add feature to detect whether the script is run in a shallow git repo. If this is the case, don't trust git file information.